### PR TITLE
Bug fix where default tab does not have the slug 'default_tab'

### DIFF
--- a/admin/settings/class-plugin-name-sanitization-helper.php
+++ b/admin/settings/class-plugin-name-sanitization-helper.php
@@ -109,7 +109,7 @@ class Plugin_Name_Sanitization_Helper {
 		}
 
 		parse_str( $_POST['_wp_http_referer'], $referrer );
-		$tab = isset( $referrer['tab'] ) ? $referrer['tab'] : 'default_tab';
+		$tab = isset( $referrer['tab'] ) ? $referrer['tab'] : Plugin_Name_Settings_Definition::get_default_tab_slug();
 
 		// Tab filter
 		$input = apply_filters( $this->snake_cased_plugin_name . '_settings_sanitize_' . $tab, $input );


### PR DESCRIPTION
Hard coding the default tab as "default_tab" can be problematic when extending this module's functionality. I ran into a case where my default tab was not named "default_tab" and I was not using the query string "&tab=" in my settings page. When I attempted to save the settings it was unable to get the tab name from the query string and was falling back to "default_tab" which is hard coded.

There is a viable function in the 'Plugin_Name_Settings_Definition' class which can get the default tab called 'get_default_tab_slug', I suggest using this function over hard coding.
